### PR TITLE
fix: 修复Star History图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,4 +430,4 @@ WeChat Pay：
 
 ## ⏰ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=P1kaj1uu/ChattyPlay-Agent&type=Timeline)](https://star-history.com/#P1kaj1uu/ChattyPlay-Agent&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=P1kaj1uu/ChattyPlay-Agent&type=Timeline)](https://star-history.dera.page/#P1kaj1uu/ChattyPlay-Agent&Timeline)


### PR DESCRIPTION
当前README中的Star History图表已经失效，原因是GitHub stargazer API的限制。现将图表迁移到star-history.dera.page这个新的数据源上，无需API token即可正常显示Star增长趋势。